### PR TITLE
Use forked version of postcss-amp for now to whitelist @supports

### DIFF
--- a/examples/assets/sample.scss
+++ b/examples/assets/sample.scss
@@ -4,3 +4,9 @@ body {
   background-color: $primary;
   margin: 0 !important;
 }
+
+.grid {
+  @supports (display: grid) {
+    display: grid;
+  }
+}

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,7 +1,7 @@
 const postCSS = require('postcss');
 const sass = require('node-sass');
 const autoprefixer = require('autoprefixer');
-const postAMP = require('postcss-amp');
+const postAMP = require('@texastribune/postcss-amp');
 const CleanCSS = require('clean-css');
 
 let postCSSPlugins = [autoprefixer({ grid: true })];

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "np": "^5.0.3"
   },
   "dependencies": {
+    "@texastribune/postcss-amp": "^1.4.0",
     "amphtml-validator": "^1.0.23",
     "autoprefixer": "^9.6.0",
     "clean-css": "^4.2.1",
@@ -83,7 +84,6 @@
     "node-sass": "^4.12.0",
     "ora": "^3.4.0",
     "postcss": "^7.0.17",
-    "postcss-amp": "^1.4.0",
     "svgo": "^1.2.2",
     "svgstore": "^3.0.0-2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,6 +325,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@texastribune/postcss-amp@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@texastribune/postcss-amp/-/postcss-amp-1.4.0.tgz#fb96d58eb5707cadf2ae9d10db697752697cae41"
+  integrity sha512-YqYumCnu/8L6awDD5GtSgAv3N8Wsgj7yU4Ipwhqdld4Sw8b2yvoIXMupR4nre2A61JQAOMs+Li7ECkNH2iz40w==
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
@@ -4777,11 +4782,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
-
-postcss-amp@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/postcss-amp/-/postcss-amp-1.4.0.tgz#0290aca9b8b11718a6e7ec5e6309226aba8d1ff7"
-  integrity sha512-TQZO5UsPo8x+386lDRK/2AayudSX6IMD4Kp7U1rH27cwnARVa9oFMydezhu2Jre8PSI3i2PYrQtuMeC+/p56ng==
 
 postcss-value-parser@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
@AndrewGibson27, just a heads up: I created a [forked version](https://github.com/texastribune/postcss-amp) of postcss-amp, because it was stripping the `@supports` selector, which is needed for the photo grid. This is hopefully just a temp solution.