### PR TITLE
Don't rely on comparing files to determine hash change

### DIFF
--- a/lib/hash-files.js
+++ b/lib/hash-files.js
@@ -1,86 +1,52 @@
 const ora = require('ora');
 const fs = require('fs-extra');
 const path = require('path');
+const md5File = require('md5-file');
 
 const spinner = ora();
 
-const hasChanged = (dirMap, oldManifest) => {
-  const { out } = dirMap;
-  const ext = path.extname(out);
-  const baseName = path.basename(out, ext);
+const getFileName = file => path.basename(file, path.extname(file));
 
-  if (typeof oldManifest[baseName] !== 'undefined') {
-    const bustedLocation = `${path.dirname(out)}/${oldManifest[baseName]}`;
-    const oldCSS = fs.readFileSync(bustedLocation);
-    const newCSS = fs.readFileSync(out);
-    return oldCSS.toString() !== newCSS.toString();
-  }
-  return true;
+const getHashName = file => {
+  return `${getFileName(file)}.${md5File.sync(file)}${path.extname(file)}`;
 };
 
-const createManifest = async (oldManifest, hasMap, manifest) => {
-  const hashMapObj = {};
-  hasMap.forEach(file => {
-    hashMapObj[file.baseName] = file.bustedName;
-  });
-  const merged = { ...oldManifest, ...hashMapObj };
+const createHashFile = async file => {
+  const dir = path.dirname(file);
+  const hashedLocation = `${dir}/${getHashName(file)}`;
+  const css = fs.readFileSync(file);
   try {
-    await fs.outputFile(manifest, JSON.stringify(merged, null, 2));
-  } catch (err) {
-    throw err;
-  }
-};
-
-const createHashFile = async hashObj => {
-  const css = fs.readFileSync(hashObj.rawLocation);
-  try {
-    await fs.outputFile(hashObj.bustedLocation, css.toString());
-    spinner.info(`Added: ${hashObj.bustedLocation}`);
+    await fs.outputFile(hashedLocation, css.toString());
+    spinner.info(`Added: ${hashedLocation}`);
   } catch (err) {
     throw new Error(err.message);
   }
 };
 
-const createHashObj = file => {
-  const ext = path.extname(file);
-  const baseName = path.basename(file, ext);
-  const bustedName = `${baseName}.${Date.now()}${ext}`;
-  const bustedLocation = `${path.dirname(file)}/${bustedName}`;
-  const rawLocation = `${path.dirname(file)}/${baseName}${ext}`;
-  return {
-    baseName,
-    bustedName,
-    bustedLocation,
-    rawLocation,
-  };
-};
+const arrayToObject = (arr, keyField, valueField) =>
+  Object.assign(
+    {},
+    ...arr.map(item => ({ [item[keyField]]: [item[valueField]] }))
+  );
 
 module.exports = async (dirs, manifest) => {
   spinner.start('Hash CSS files');
 
-  // get old manifest map for diffing files
-  let oldManifest = {};
+  // create hashed files
+  await Promise.all(dirs.map(file => createHashFile(file.out)));
+
+  // create an array of files/hash files
+  const hashArr = dirs.map(file => {
+    return {
+      file: getFileName(file.out),
+      hash: getHashName(file.out),
+    };
+  });
+  // generate manifest of files {name: locations/name.hash.css}
+  const hashObj = arrayToObject(hashArr, 'file', 'hash');
+
   try {
-    oldManifest = await fs.readJson(manifest);
-  } catch (error) {
-    spinner.info(`No styles manifest found in: ${manifest}`);
-    spinner.info(`Generating a new one...`);
-  }
-
-  // get changed files
-  const changedFiles = await Promise.all(
-    dirs.filter(dirMap => hasChanged(dirMap, oldManifest))
-  );
-
-  // generate array of hash info
-  const newHashes = changedFiles.map(dirMap => createHashObj(dirMap.out));
-
-  // create new/updated files
-  await Promise.all(newHashes.map(file => createHashFile(file)));
-
-  // write a manifest of files {name: locations/name.hash.css}
-  try {
-    await createManifest(oldManifest, newHashes, manifest);
+    await fs.outputFile(manifest, JSON.stringify(hashObj, null, 2));
   } catch (error) {
     throw new Error(error.message);
   }

--- a/lib/hash-files.js
+++ b/lib/hash-files.js
@@ -26,8 +26,20 @@ const createHashFile = async file => {
 const arrayToObject = (arr, keyField, valueField) =>
   Object.assign(
     {},
-    ...arr.map(item => ({ [item[keyField]]: [item[valueField]] }))
+    ...arr.map(item => ({ [item[keyField]]: item[valueField] }))
   );
+
+const duplicates = arr => {
+  const seen = new Set();
+  const store = [];
+  arr.filter(
+    item =>
+      seen.size === seen.add(item).size &&
+      !store.includes(item) &&
+      store.push(item)
+  );
+  return store;
+};
 
 module.exports = async (dirs, manifest) => {
   spinner.start('Hash CSS files');
@@ -42,6 +54,16 @@ module.exports = async (dirs, manifest) => {
       hash: getHashName(file.out),
     };
   });
+
+  // check for duplicate file names
+  const fileDuplicates = duplicates(hashArr.map(item => item.file));
+  if (fileDuplicates.length > 0) {
+    fileDuplicates.forEach(name => {
+      spinner.fail(`Multiple files named "${name}" exist directory map. Rename one of them.`);
+    });
+    throw new Error('Manifest keys must be unique.');
+  }
+
   // generate manifest of files {name: locations/name.hash.css}
   const hashObj = arrayToObject(hashArr, 'file', 'hash');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6751,6 +6751,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+      "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "clean-css": "^4.2.1",
     "fast-glob": "^3.0.1",
     "fs-extra": "^8.0.1",
+    "md5-file": "^4.0.0",
     "node-sass": "^4.13.1",
     "ora": "^4.0.2",
     "postcss": "^7.0.17",


### PR DESCRIPTION
This should be a _much_ more reasonable way to create a hashed file name. Before, we hacked together a hashed-name based on a date and whether or not the contents of the file had changed. Now we use an md5 hash which eliminates the need to extract any previous content to compare.
