### PR TITLE
Add helper for copying files and directories

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,10 +1,11 @@
-const { styles, icons, amp } = require('../lib');
-const { AMP_MAP, CSS_MAP, MANIFEST_FILE, SVG_MAP } = require('./paths');
+const { styles, icons, amp, copy } = require('../lib');
+const { AMP_MAP, CSS_MAP, MANIFEST_FILE, SVG_MAP, COPY_MAP } = require('./paths');
 
 async function build() {
   await styles(CSS_MAP, MANIFEST_FILE);
   await icons(SVG_MAP);
   await amp(AMP_MAP);
+  await copy(COPY_MAP);
 }
 
 build().catch(err => {

--- a/examples/paths.js
+++ b/examples/paths.js
@@ -29,6 +29,17 @@ const SVG_MAP = [
   },
 ];
 
+const COPY_MAP = [
+  {
+    in: inputPath('bug.svg'),
+    out: outputPath('copied-file/bug.svg'),
+  },
+  {
+    in: inputPath('icons'),
+    out: outputPath('copied-dir/icons'),
+  },
+];
+
 const MANIFEST_FILE = outputPath('styles.json');
 
 module.exports = {
@@ -36,4 +47,5 @@ module.exports = {
   CSS_MAP,
   SVG_MAP,
   MANIFEST_FILE,
+  COPY_MAP,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 const SCSS_SUCCESS = 'Compiled SCSS';
 const SVG_SUCCESS = 'Built sprite';
 const AMP_SUCCESS = 'Built AMP stylesheet';
+const COPY_SUCCESS = 'Copied assets';
 const AMP_BOILERPLATE = `<!doctype html>
 <html amp lang="en">
   <head>
@@ -19,6 +20,7 @@ const AMP_BOILERPLATE = `<!doctype html>
 module.exports = {
   AMP_BOILERPLATE,
   AMP_SUCCESS,
+  COPY_SUCCESS,
   SCSS_SUCCESS,
   SVG_SUCCESS,
 };

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,0 +1,34 @@
+// utility packages
+const fs = require('fs-extra');
+const ora = require('ora');
+
+// internal
+const { COPY_SUCCESS } = require('./constants');
+
+const spinner = ora();
+
+const copyDirs = async dirMap => {
+  try {
+    await fs.copy(dirMap.in, dirMap.out, { preserveTimestamps: true });
+  } catch (err) {
+    spinner.warn(
+      'Copying assets: Note that if input is a file, output cannot be a directory.'
+    );
+    throw err
+  }
+  return COPY_SUCCESS;
+};
+
+module.exports = async dirs => {
+  spinner.start('Copying assets');
+
+  return Promise.all(dirs.map(dirMap => copyDirs(dirMap)))
+    .then(resp => {
+      spinner.succeed();
+      return resp;
+    })
+    .catch(error => {
+      spinner.fail();
+      throw new Error(error.message);
+    });
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,12 @@ const styles = require('./styles.js');
 const icons = require('./icons.js');
 const utils = require('./utils.js');
 const amp = require('./amp.js');
+const copy = require('./copy.js');
 
 module.exports = {
   styles,
   icons,
   utils,
   amp,
+  copy
 };

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -1,0 +1,8 @@
+const { copy } = require('../lib');
+const { COPY_MAP } = require('../examples/paths');
+const { COPY_SUCCESS } = require('../lib/constants');
+
+it('Copies directories or files', async () => {
+  const data = await copy(COPY_MAP);
+  expect(data).toStrictEqual([COPY_SUCCESS, COPY_SUCCESS]);
+});


### PR DESCRIPTION
Adds a simple way to call fs.copy for an array of inputs and outputs. We could use this to quickly move queso-ui assets like shared logos or raw SVG icons from node_modules into our static folder in django.