### PR TITLE
Only use node versions with security updates in actions checks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This autoprefixer [release note](https://github.com/postcss/postcss/releases/tag/8.0.0) led me to believe versions of node 11.x don't receive security updates:
> PostCSS 8 dropped Node.js 6.x, 8.x, 11.x, and 13.x versions support. All these versions have no security updates anymore.

For that reason, it seems fair to stop running 11.x node environments through our CI tests.