### PR TITLE
Bump amp-validator from 1.0.23 to 1.0.35

### DIFF
--- a/examples/paths.js
+++ b/examples/paths.js
@@ -1,17 +1,13 @@
 const path = require('path');
 const { resolveApp } = require('../lib/utils');
 
-const inputPath = file => resolveApp(path.join('examples', 'assets', file));
-const outputPath = file => resolveApp(path.join('dist', file));
+const inputPath = (file) => resolveApp(path.join('examples', 'assets', file));
+const outputPath = (file) => resolveApp(path.join('dist', file));
 
 const AMP_MAP = [
   {
     in: inputPath('sample.scss'),
     out: outputPath('amp-styles.html'),
-  },
-  {
-    in: inputPath('queso.scss'),
-    out: outputPath('queso-amp-styles.html'),
   },
 ];
 
@@ -24,7 +20,6 @@ const CSS_MAP = [
     in: inputPath('queso.scss'),
     out: outputPath('queso.css'),
   },
-
 ];
 
 const SVG_MAP = [

--- a/lib/amp.js
+++ b/lib/amp.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const ora = require('ora');
-const amphtmlValidator = require('amphtml-validator');
+const { getInstance } = require('amphtml-validator');
 const compile = require('./compile');
 const { logMessage, getSize } = require('./utils');
 const { AMP_BOILERPLATE, AMP_SUCCESS } = require('./constants');
@@ -20,7 +20,7 @@ const processAMP = async dirs => {
 
   // run a validation check
   const html = AMP_BOILERPLATE.replace('{{injectAMP}}', css);
-  const validator = await amphtmlValidator.getInstance();
+  const validator = await getInstance();
   let resp = {};
   try {
     resp = validator.validateString(html);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
-        "amphtml-validator": "^1.0.23",
+        "amphtml-validator": "^1.0.35",
         "autoprefixer": "^10.1.0",
         "clean-css": "^4.2.1",
         "fast-glob": "^3.0.1",
@@ -1887,14 +1887,13 @@
       }
     },
     "node_modules/amphtml-validator": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.33.tgz",
-      "integrity": "sha512-NAamUl3flAku2DLc/OKEPpR2BQJBQTG+iW7HFeJDDvsZ0YwCmGsMAV97/HPaKAvUowzjA+79QjWr4z0Pscg+8g==",
-      "deprecated": "Version no longer supported. Upgrade to 1.0.35.",
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.35.tgz",
+      "integrity": "sha512-C67JzC5EI6pE2C0sAo/zuCp8ARDl1Vtt6/s0nr+3NuXDNOdkjclZUkaNAd/ZnsEvvYodkXZ6T/uww890IQh9dQ==",
       "dependencies": {
-        "colors": "1.2.5",
-        "commander": "2.15.1",
-        "promise": "8.0.1"
+        "colors": "1.4.0",
+        "commander": "7.2.0",
+        "promise": "8.1.0"
       },
       "bin": {
         "amphtml-validator": "cli.js"
@@ -2949,9 +2948,9 @@
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
     "node_modules/colors": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -2969,9 +2968,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -11162,11 +11164,11 @@
       }
     },
     "node_modules/promise": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
-      "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
       "dependencies": {
-        "asap": "~2.0.3"
+        "asap": "~2.0.6"
       }
     },
     "node_modules/prompts": {
@@ -11963,14 +11965,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/symbol-observable": {
@@ -14261,13 +14255,13 @@
       }
     },
     "amphtml-validator": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.33.tgz",
-      "integrity": "sha512-NAamUl3flAku2DLc/OKEPpR2BQJBQTG+iW7HFeJDDvsZ0YwCmGsMAV97/HPaKAvUowzjA+79QjWr4z0Pscg+8g==",
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.35.tgz",
+      "integrity": "sha512-C67JzC5EI6pE2C0sAo/zuCp8ARDl1Vtt6/s0nr+3NuXDNOdkjclZUkaNAd/ZnsEvvYodkXZ6T/uww890IQh9dQ==",
       "requires": {
-        "colors": "1.2.5",
-        "commander": "2.15.1",
-        "promise": "8.0.1"
+        "colors": "1.4.0",
+        "commander": "7.2.0",
+        "promise": "8.1.0"
       }
     },
     "ansi-align": {
@@ -15052,9 +15046,9 @@
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
     "colors": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -15066,9 +15060,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -21182,11 +21176,11 @@
       "dev": true
     },
     "promise": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
-      "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "~2.0.6"
       }
     },
     "prompts": {
@@ -21786,13 +21780,6 @@
         "csso": "^4.2.0",
         "nanocolors": "^0.1.12",
         "stable": "^0.1.8"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        }
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "np": "^7.0.0"
   },
   "dependencies": {
-    "amphtml-validator": "^1.0.23",
+    "amphtml-validator": "^1.0.35",
     "autoprefixer": "^10.1.0",
     "clean-css": "^4.2.1",
     "fast-glob": "^3.0.1",


### PR DESCRIPTION
#### What's this PR do?
Version bump and updated implementation 

#### Why are we doing this? How does it help us?
The old version was throwing a message in our tests that said:
`The native JavaScript AMPHTML Validator (validator.js) has been turned down. If you are seeing this error, update your tooling to instead load the API compatible WebAssembly AMPHTML Validator (validator_wasm.js) instead.`

I then found [this comment](https://github.com/ampproject/amphtml/issues/36110#issuecomment-1029502243) in that library's repo that led me to go ahead and update to latest version.



Upon bumping the version, we were also encountering this issue https://github.com/ampproject/amphtml/issues/37585 and implemented some of the suggestions to help remedy that.

#### How should this be manually tested?

Make sure AMP validates and the test run successfully.

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?

AMP validation is a little slower


