### PR TITLE
Hide sass warnings

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -20,6 +20,7 @@ module.exports = async config => {
       sourceComments: sourceMapOn,
       sourceMap: sourceMapOn,
       sourceMapEmbed: sourceMapOn,
+      logger: sass.Logger.silent,
     });
   } catch (err) {
     logMessage(err, 'red');


### PR DESCRIPTION
#### What's this PR do?

Silences dart-sass warnings

#### Why are we doing this? How does it help us?

We have some legacy scss that is making the build logs hard to read

#### How should this be manually tested?

Should see less output on `npm run test:examples`

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?

This should really be configurable, but this is a quick fix until we want to see the warnings again.
